### PR TITLE
chore: increase server actions body size limit

### DIFF
--- a/app/upload/step1/page.tsx
+++ b/app/upload/step1/page.tsx
@@ -27,7 +27,8 @@ const Step1 = () => {
 
   const handleSubmit = async (formData: FormData) => {
     startTransition(async () => {
-      await extractTextFromPDF(formData);
+      const extractedText = await extractTextFromPDF(formData);
+      console.log(extractedText);
     });
   };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  experimental: {
+    serverActions: { bodySizeLimit: '2mb' },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
CV files that were 2MB or larger caused application errors. I’ve increased the server action body size limit to 2MB to align with file validation and to support larger file uploads consistently